### PR TITLE
Fixes NTC Slack Link in Meetings README

### DIFF
--- a/meetings/README.md
+++ b/meetings/README.md
@@ -1,6 +1,6 @@
 ## Nautobot Community Meetings
 
-Nautobot Community meeting are held in [NTC Slack](https://slack.networktocode.com) in the `nautobot` channel.
+Nautobot Community Meetings are held in [NTC Slack](https://slack.networktocode.com) in the `#nautobot` channel.
 
 
 ### Schedule

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -1,6 +1,6 @@
 ## Nautobot Community Meetings
 
-Nautobot Community meeting are held in [NTC Slack](slack.networktocode.com) in the `nautobot` channel.
+Nautobot Community meeting are held in [NTC Slack](https://slack.networktocode.com) in the `nautobot` channel.
 
 
 ### Schedule


### PR DESCRIPTION
Link at the top of `meetings/README.md` did not specify a protocol so Github interprets that as a local path. Clicking this link should take a user to the webform to join the NTC Slack community.